### PR TITLE
accept null arrival times

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/beaverbus/ResourceMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/beaverbus/ResourceMapper.groovy
@@ -91,16 +91,19 @@ class ResourceMapper {
     }
 
     static ArrivalTime mapArrivalTime(RouteStopArrivalTime time) {
-        def eta = parseDate(time.Time).truncatedTo(ChronoUnit.SECONDS)
+        def eta = parseDate(time.Time)?.truncatedTo(ChronoUnit.SECONDS)
         new ArrivalTime(
                 vehicleID: time.VehicleID.toString(),
-                eta: eta.toString(),
+                eta: eta?.toString(),
         )
     }
 
     static final Pattern DATE_REGEX = ~/^\/Date\(([0-9]*)\)\/$/
 
     static Instant parseDate(String s) {
+        if (!s) {
+            return null
+        }
         def m = DATE_REGEX.matcher(s)
         if (!m.matches()) {
             throw new Exception("not a valid date")

--- a/src/test/groovy/edu/oregonstate/mist/beaverbus/ResourceMapperTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/beaverbus/ResourceMapperTest.groovy
@@ -81,7 +81,6 @@ class ResourceMapperTest {
 
     @Test
     void testParseDate() {
-        GroovyAssert.shouldFail { ResourceMapper.parseDate("") }
         GroovyAssert.shouldFail { ResourceMapper.parseDate("Date(0)") }
         GroovyAssert.shouldFail { ResourceMapper.parseDate("/Date(xxx)/") }
         GroovyAssert.shouldFail { ResourceMapper.parseDate("xxx/Date(1)/xxx") }
@@ -89,5 +88,7 @@ class ResourceMapperTest {
         assert ResourceMapper.parseDate("/Date(0)/").toString() == "1970-01-01T00:00:00Z"
         assert ResourceMapper.parseDate("/Date(946684800000)/") == Instant.ofEpochMilli(946684800000)
         assert ResourceMapper.parseDate("/Date(946684800000)/").toString() == "2000-01-01T00:00:00Z"
+        assert ResourceMapper.parseDate("") == null
+        assert ResourceMapper.parseDate(null) == null
     }
 }


### PR DESCRIPTION
Sometimes, ride systems gives a null eta. This is not ideal, but we don't want this to fail the entire response. The arrivals endpoint is meant to be hit constantly, so a null eta every so often shouldn't be a big issue.